### PR TITLE
Windows support

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,7 +208,11 @@ func killPort(pid string) {
 	if err != nil {
 		log.Error("Could not convert to process pid to int")
 	}
-	syscall.Kill(pidInt, syscall.SIGKILL)
+	proc, err := os.FindProcess(pidInt)
+	if err != nil {
+		log.Error(err)
+	}
+	err = proc.Signal(syscall.SIGKILL)
 	if err != nil {
 		log.Error("Could not kill process")
 	}


### PR DESCRIPTION
### Added support for Windows
**Restrictions:**

- Powershell needs elevated privilege to run "Get-Process" with "-IncludeUserName" parameter.
    - If run withing non privileged session, usernames will not appear.

**Problems:**

- Trying to kill ports using filter causes panic

    ```
    Caught panic:
    
    runtime error: invalid memory address or nil pointer dereference
    
    Restoring terminal...
    
    goroutine 1 [running]:
    runtime/debug.Stack()
            C:/Program Files/Go/src/runtime/debug/stack.go:24 +0x65
    runtime/debug.PrintStack()
            C:/Program Files/Go/src/runtime/debug/stack.go:16 +0x19
    github.com/charmbracelet/bubbletea.(*Program).Run.func1()
            C:/Users/vujov/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.23.2/tea.go:402 +0x95
    panic({0x1170100, 0x131f7f0})
            C:/Program Files/Go/src/runtime/panic.go:890 +0x263
    main.model.Update({{0x0, 0x1, 0x1, 0x1, 0x1, 0x1, {0x1197d1c, 0x7}, {0x1198537, 0x9}, ...}, ...}, ...)
            D:/GitHub/gruyere/main.go:110 +0x596
    github.com/charmbracelet/bubbletea.(*Program).eventLoop(0xc00018c000, {0x11dc478?, 0xc000071b00?}, 0x100458a?)
            C:/Users/vujov/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.23.2/tea.go:343 +0x60a
    github.com/charmbracelet/bubbletea.(*Program).Run(0xc00018c000)
            C:/Users/vujov/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.23.2/tea.go:465 +0x81d
    main.main()
            D:/GitHub/gruyere/main.go:178 +0x285
    ```
- UI is messed up on Windows terminals

![image](https://user-images.githubusercontent.com/78181427/222902228-a54a321a-7194-4c66-b9b3-39eeef01c4a5.png)
