### PR TITLE
Faster (non-blocking) update of processes

### DIFF
--- a/main.go
+++ b/main.go
@@ -182,7 +182,7 @@ func main() {
 
 // Used to refresh the running processes on listening ports in the list view
 func tickCmd() tea.Cmd {
-	return tea.Tick(time.Second*1, func(t time.Time) tea.Msg {
+	return tea.Tick(time.Millisecond*600, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
 }

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		if numOfGoroutines == 0 {
 			numOfGoroutines = runtime.NumGoroutine()
-		} else if numOfGoroutines == runtime.NumGoroutine() {
+		} else if numOfGoroutines >= runtime.NumGoroutine() {
 			go func() {
 				processes = getProcesses()
 			}()

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func (m model) View() string {
 
 func main() {
 	// Get processes running on listening ports
-	processes := getProcesses()
+	processes = getProcesses()
 
 	//Initialize the model
 	m := model{


### PR DESCRIPTION
On first update, it will determine base number of goroutines and make sure to never get to the point where cmd execution(getProcesses) will be slower than ticking time and flooding with number of goroutines.