### PR TITLE
killPort() tweaks

### DIFF
--- a/main.go
+++ b/main.go
@@ -204,11 +204,12 @@ func getProcesses() []list.Item {
 }
 
 func killPort(pid string) {
+	var err error
 	pidInt, err := strconv.Atoi(pid)
 	if err != nil {
 		log.Error("Could not convert to process pid to int")
 	}
-	syscall.Kill(pidInt, syscall.SIGKILL)
+	err = syscall.Kill(pidInt, syscall.SIGKILL)
 	if err != nil {
 		log.Error("Could not kill process")
 	}

--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func killPort(pid string) {
 	pidInt, err := strconv.Atoi(pid)
 	if err != nil {
 		log.Error("Could not convert to process pid to int")
+		return
 	}
 	err = syscall.Kill(pidInt, syscall.SIGKILL)
 	if err != nil {


### PR DESCRIPTION
thanks for the cool project! i saw it pop up in my feed the other day and i was taking a look at the code since i'm learning go. i'm sorry if my changes don't make sense. the updates are to return early from `killPort()` if the string to int conversion fails and to assign and check the error returned from `syscall.Kill()`