### PR TITLE
feat: add h and l as keybindings to select confirmation buttons

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,10 +115,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// If we reach the dialog to confirm killing a port (and therefore have selected a port)
-		if msg.String() == "right" && m.activeButton != "no" {
+		if (msg.String() == "right" || msg.String() == "l") && m.activeButton != "no" {
 			m.activeButton = "no"
 		}
-		if msg.String() == "left" && m.activeButton == "no" {
+		if (msg.String() == "left" || msg.String() == "h") && m.activeButton == "no" {
 			m.activeButton = "yes"
 		}
 


### PR DESCRIPTION
### Vim style bindings for the confirmation buttons

Since we already use `k` and `j` to move up and down the processes, it feels more intuitive(for me a dirty vim user) to be able to use `h` and `l` to select buttons as well