### PR TITLE
Handle no processes found

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Select a port
-		if msg.String() == "enter" {
+		if msg.String() == "enter" && len(m.list.Items()) > 0 {
 			if m.selectedPort == "" {
 				port := m.list.SelectedItem().FilterValue()
 				m.selectedPort = port
@@ -178,12 +178,15 @@ func tickCmd() tea.Cmd {
 	})
 }
 
-func getProcesses() []list.Item {
-	out, _ := exec.Command("lsof", "-i", "-P", "-n", "-sTCP:LISTEN").Output()
+func getProcesses() (processes []list.Item) {
+	processes = []list.Item{}
+	out, err := exec.Command("lsof", "-i", "-P", "-n", "-sTCP:LISTEN").Output()
+	if err != nil {
+		return
+	}
 	strStdout := string(out)
 
 	procs := strings.Split(strStdout, "\n")
-	var processes []list.Item
 	for i, proc := range procs {
 		if len(proc) == 0 || i == 0 {
 			continue
@@ -200,7 +203,7 @@ func getProcesses() []list.Item {
 		processes = append(processes, item{title: titleStr, desc: descStr})
 	}
 
-	return processes
+	return
 }
 
 func killPort(pid string) {


### PR DESCRIPTION
Resolves issue #5 

Updated the `getProcesses` function to ensure that an empty `list.Item` slice is able to be returned.
- Line 181, changed the return to `(processes []list.Item)`
- Line 182, initialise the empty slice
- Line 183-186, take in an error from the command execution & return the empty slice if there is an error found.
- Line 206, updated the `return` to remove `processes` as it is not required

Updated the `Update` function to check that the number of items is more than 0.
- Line 98, added `&& len(m.list.Items()) > 0` to the test.