### PR TITLE
fix: better way to handle no process

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,10 +93,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.String() == "ctrl+c" {
 			return m, tea.Quit
 		}
-		
-		// If there are no running processes, dont allow user to select
-		hasRunningProcesses := len(m.list.Items()) > 0
-		if msg.String() == "enter" && hasRunningProcesses {
+
+		if msg.String() == "enter" && m.list.SelectedItem() != nil {
 			if m.selectedPort == "" {
 				port := m.list.SelectedItem().FilterValue()
 				m.selectedPort = port
@@ -185,7 +183,7 @@ func getProcesses() []list.Item {
 	if err != nil {
 		return []list.Item{}
 	}
-	
+
 	strStdout := string(out)
 
 	procs := strings.Split(strStdout, "\n")


### PR DESCRIPTION
We recently put a fix for user pressing "enter" when there are no processes and crash in this pr: https://github.com/savannahostrowski/gruyere/pull/20

While do different dev work I realized that this doesnt handle the case if the user is filtering, the filtering shows no results and then the user presses "enter". 

This pr is a better way to handle both cases at once
- Solves "enter" when no processes on list
- Solves "enter" when no processes found when filtering