### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines and whitespace cleanup
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Protect whitespace in markdown files
+[*.md]
+trim_trailing_whitespace = false
+
+# general formatting
+[*.{bash,go,sh,zsh,justfile,Makefile}]
+indent_style = tab
+indent_size = 4
+
+# Set default charset
+[*.{html,xml,js,css,py}]
+charset = utf-8
+
+# python
+[*.py]
+indent_style = space
+indent_size = 4
+
+# webdev et al
+[*.{html,xml,js,css,json,jsonc,gql,lua,tf,tfvars,yml,yaml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
EditorConfig is pretty straightforward. Add the extension to whatever your IDE/editor is, drop the config into the root of the repo, and henceforth don't clobber other people's work with crazy formatting modifications (e.g., stripped whitespace on 1000+ lines).

The only not-so-obvious line is `root = true`; from the [docs](https://editorconfig.org/):
> When opening a file, EditorConfig plugins look for a file named .editorconfig in the directory of the opened file and in every parent directory. A search for .editorconfig files will stop if the root filepath is reached or an EditorConfig file with root=true is found.

Happy to remove whatever you think isn't necessary, but honestly if it's not used, it's kinda like forwarding a udp port when only tcp is listening 😼 

Closes #29 